### PR TITLE
Azure Updates for ManagedClientConsoleAppSample/README.md

### DIFF
--- a/ManagedClientConsoleAppSample/README.md
+++ b/ManagedClientConsoleAppSample/README.md
@@ -36,7 +36,7 @@ If you are a Microsoft Account backed Azure DevOps account please skip this step
 2. On the top bar, click on your account and under the Directory list, choose the Active Directory tenant where you wish to register your application.
 3. On the left hand navigation menu, select `Azure Active Directory`.
 4. Click on `App registrations` and select `New registration` from the top bar.
-5. Enter a `Name` for you application, ex. "Adal native app sample", choose a Supported account type as required, ex. to be on the save site for testing, take the third option, then select `Public client (mobile & desktop)` in `Redirect URI` dropdown and enter `urn:ietf:wg:oauth:2.0:oob` as the URI in the text box next to it. Finally click `create` at the bottom of the screen.
+5. Enter a `Name` for your application, ex. "Adal native app sample", choose a `Supported account type` as required, ex. to be on the save site for testing, take the third option, then select `Public client (mobile & desktop)` in `Redirect URI` dropdown and enter `urn:ietf:wg:oauth:2.0:oob` as the URI in the text box next to it. Finally click `create` at the bottom of the screen.
 6. Save the `Application ID` from your new application registration. You will need it later in this sample.
 7. Grant permissions for Azure DevOps. Click `API Permissions` -> `Add a permission` -> `1 Select an API` -> type in and select `Azure DevOps` -> check the box for `user_impersonation` -> click `Add permissions`.
 

--- a/ManagedClientConsoleAppSample/README.md
+++ b/ManagedClientConsoleAppSample/README.md
@@ -36,7 +36,7 @@ If you are a Microsoft Account backed Azure DevOps account please skip this step
 2. On the top bar, click on your account and under the Directory list, choose the Active Directory tenant where you wish to register your application.
 3. On the left hand navigation menu, select `Azure Active Directory`.
 4. Click on `App registrations` and select `New application registration` from the top bar.
-5. Enter a `name` for you application, ex. "Adal native app sample", choose `Native` for `application type`, and enter `http://adalsample` for the `Redirect URI`. Finally click `create` at the bottom of the screen.
+5. Enter a `name` for you application, ex. "Adal native app sample", choose `InstalledClient` for `application type`, and enter `urn:ietf:wg:oauth:2.0:oob` for the `Redirect URI`. Finally click `create` at the bottom of the screen.
 6. Save the `Application ID` from your new application registration. You will need it later in this sample.
 7. Grant permissions for Azure DevOps. Click `Required permissions` -> `add` -> `1 Select an API` -> type in and select `Azure DevOps (Microsoft Visual Studio Team Services)` -> check the box for `Delegated Permissions` -> click `Select` -> click `Done` -> click `Grant Permissions` -> click `Yes`.
 

--- a/ManagedClientConsoleAppSample/README.md
+++ b/ManagedClientConsoleAppSample/README.md
@@ -36,9 +36,9 @@ If you are a Microsoft Account backed Azure DevOps account please skip this step
 2. On the top bar, click on your account and under the Directory list, choose the Active Directory tenant where you wish to register your application.
 3. On the left hand navigation menu, select `Azure Active Directory`.
 4. Click on `App registrations` and select `New registration` from the top bar.
-5. Enter a `Name` for you application, ex. "Adal native app sample", choose a Supported account type as required, ex. the first option, then select `Public client (mobile & desktop)` in `Redirect URI` dropdown and enter `urn:ietf:wg:oauth:2.0:oob` as the URI in the text box next to it. Finally click `create` at the bottom of the screen.
+5. Enter a `Name` for you application, ex. "Adal native app sample", choose a Supported account type as required, ex. to be on the save site for testing, take the third option, then select `Public client (mobile & desktop)` in `Redirect URI` dropdown and enter `urn:ietf:wg:oauth:2.0:oob` as the URI in the text box next to it. Finally click `create` at the bottom of the screen.
 6. Save the `Application ID` from your new application registration. You will need it later in this sample.
-7. Grant permissions for Azure DevOps. Click `Required permissions` -> `add` -> `1 Select an API` -> type in and select `Azure DevOps (Microsoft Visual Studio Team Services)` -> check the box for `Delegated Permissions` -> click `Select` -> click `Done` -> click `Grant Permissions` -> click `Yes`.
+7. Grant permissions for Azure DevOps. Click `API Permissions` -> `Add a permission` -> `1 Select an API` -> type in and select `Azure DevOps` -> check the box for `user_impersonation` -> click `Add permissions`.
 
 ## Step 3: Install and configure ADAL (optional)
 

--- a/ManagedClientConsoleAppSample/README.md
+++ b/ManagedClientConsoleAppSample/README.md
@@ -35,8 +35,8 @@ If you are a Microsoft Account backed Azure DevOps account please skip this step
 1. Sign in to the [Azure Portal](https://portal.azure.com).
 2. On the top bar, click on your account and under the Directory list, choose the Active Directory tenant where you wish to register your application.
 3. On the left hand navigation menu, select `Azure Active Directory`.
-4. Click on `App registrations` and select `New application registration` from the top bar.
-5. Enter a `name` for you application, ex. "Adal native app sample", choose `InstalledClient` for `application type`, and enter `urn:ietf:wg:oauth:2.0:oob` for the `Redirect URI`. Finally click `create` at the bottom of the screen.
+4. Click on `App registrations` and select `New registration` from the top bar.
+5. Enter a `Name` for you application, ex. "Adal native app sample", choose a Supported account type as required, ex. the first option, then select `Public client (mobile & desktop)` in `Redirect URI` dropdown and enter `urn:ietf:wg:oauth:2.0:oob` as the URI in the text box next to it. Finally click `create` at the bottom of the screen.
 6. Save the `Application ID` from your new application registration. You will need it later in this sample.
 7. Grant permissions for Azure DevOps. Click `Required permissions` -> `add` -> `1 Select an API` -> type in and select `Azure DevOps (Microsoft Visual Studio Team Services)` -> check the box for `Delegated Permissions` -> click `Select` -> click `Done` -> click `Grant Permissions` -> click `Yes`.
 


### PR DESCRIPTION
Brought Step 2 (Register App in Azure) up to date, as the Azure Portal changed over time and the current documentation became meanwhile somewhat confusing/missleading.

Some examples:
1. When registering an app in Azure, there is no more option "native", the name is "Public client (mobile & desktop)". --> Updated application type key to correct value
2. The ReplyUri of the registration and the application itself must be the same. In the source code, the replyUri is set to "urn:ietf:wg:oauth:2.0:oob", therefore, to prevent errors, it makes sense, to set it to the same value also when registering in Azure. (value before was "http://adalsample") --> Updated reply URL to a value that is in sync with the source code of the sample.