### PR TITLE
Fixes the "authorize" URL in the OAuthWebsample index view

### DIFF
--- a/OAuthWebSample/OAuthWebSample/Views/Home/Index.cshtml
+++ b/OAuthWebSample/OAuthWebSample/Views/Home/Index.cshtml
@@ -10,7 +10,7 @@
 <div class="jumbotron">
     <h1>Azure DevOps OAuth Client Sample</h1>
     <p class="lead">This app shows how to authorize a user to authorize an app and then to request an access token to access Azure DevOps on their behalf.</p>
-    <p><a href="/oauth/requesttoken" class="btn btn-primary btn-large"  >Authorize &raquo;</a></p>
+    <p><a href="@Url.Action("Authorize", "OAuth")" class="btn btn-primary btn-large"  >Authorize &raquo;</a></p>
 </div>
 
 <div class="row">


### PR DESCRIPTION
Fixes the incorrect "authorize" URL in the OAuthWebsample's Index view, introduced by bad-merge commit 2ef123ce16d3fd97a5ea7a0b5123de0b9bd998bd