### PR TITLE
Use `https` in `ado:OrganizationUrl`

### DIFF
--- a/ManagedClientConsoleAppSample/App.config
+++ b/ManagedClientConsoleAppSample/App.config
@@ -40,6 +40,6 @@
         <add key="ida:AADInstance" value="https://login.microsoftonline.com/{0}/v2.0" />
       
         <!--URL of Azure DevOps organization-->      
-        <add key="ado:OrganizationUrl" value="http://dev.azure.com/organization" />
+        <add key="ado:OrganizationUrl" value="https://dev.azure.com/organization" />
     </appSettings>
 </configuration>


### PR DESCRIPTION
The instruction clearly says `ado:OrganizationUrl` should use HTTPS.

https://github.com/microsoft/azure-devops-auth-samples/blob/49f055dfb806473f035f16f7780d1fe319e63b81/ManagedClientConsoleAppSample/README.md#L59

Use `http://dev.azure.com/organization` causes confusion and leads to failure:

```
# PowerShell
> az rest --url '"http://dev.azure.com/azure-sdk/_apis/projects?stateFilter=All&api-version=2.2"' --resource 499b84ac-1321-427f-aa17-267ca6975798

... Microsoft Internet Explorer&#39;s Enhanced Security Configuration is currently enabled on your environment. This enhanced level of security prevents our web integration experiences from displaying or performing correctly. To continue with your operation please disable this configuration or contact your administrator. ...
```