### PR TITLE
Use VssAzureIdentityCredential in examples

### DIFF
--- a/ServicePrincipalsSamples/ClientLibsNET/0-SimpleConsoleApp-AppRegistration/0-SimpleConsoleApp-AppRegistration.csproj
+++ b/ServicePrincipalsSamples/ClientLibsNET/0-SimpleConsoleApp-AppRegistration/0-SimpleConsoleApp-AppRegistration.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.8.1" />
-    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="19.219.0-preview" />
-    <PackageReference Include="Microsoft.VisualStudio.Services.InteractiveClient" Version="19.219.0-preview" />
+    <PackageReference Include="Azure.Identity" Version="1.11.3" />
+    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="19.239.0-preview" />
+    <PackageReference Include="Microsoft.VisualStudio.Services.InteractiveClient" Version="19.239.0-preview" />
   </ItemGroup>
 
 </Project>

--- a/ServicePrincipalsSamples/ClientLibsNET/0-SimpleConsoleApp-AppRegistration/Program.cs
+++ b/ServicePrincipalsSamples/ClientLibsNET/0-SimpleConsoleApp-AppRegistration/Program.cs
@@ -38,11 +38,7 @@ else
 // Whenever possible, credential instance should be reused for the lifetime of the process.
 // An internal token cache is used which reduces the number of outgoing calls to Azure AD to get tokens.
 // Call GetTokenAsync whenever you are making a request. Token caching and refresh logic is handled by the credential object.
-var tokenRequestContext = new TokenRequestContext(VssAadSettings.DefaultScopes);
-var accessToken = await credential.GetTokenAsync(tokenRequestContext, CancellationToken.None);
-
-var vssAadToken = new VssAadToken("Bearer", accessToken.Token);
-var vssAadCredentials = new VssAadCredential(vssAadToken);
+var vssAadCredentials = new VssAzureIdentityCredential(credential);
 
 var orgUrl = new Uri(new Uri(AdoBaseUrl), AdoOrgName);
 var connection = new VssConnection(orgUrl, vssAadCredentials);

--- a/ServicePrincipalsSamples/ClientLibsNET/2-ConsoleApp-ManagedIdentity/2-ConsoleApp-ManagedIdentity.csproj
+++ b/ServicePrincipalsSamples/ClientLibsNET/2-ConsoleApp-ManagedIdentity/2-ConsoleApp-ManagedIdentity.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.8.2" />
-    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="19.219.0-preview" />
-    <PackageReference Include="Microsoft.VisualStudio.Services.InteractiveClient" Version="19.219.0-preview" />
+    <PackageReference Include="Azure.Identity" Version="1.11.3" />
+    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="19.239.0-preview" />
+    <PackageReference Include="Microsoft.VisualStudio.Services.InteractiveClient" Version="19.239.0-preview" />
   </ItemGroup>
 
 </Project>

--- a/ServicePrincipalsSamples/ClientLibsNET/2-ConsoleApp-ManagedIdentity/Program.cs
+++ b/ServicePrincipalsSamples/ClientLibsNET/2-ConsoleApp-ManagedIdentity/Program.cs
@@ -28,7 +28,7 @@ namespace ServicePrincipalsSamples
             Console.Write("Work item ID: ");
             int workItemId = Convert.ToInt32(Console.ReadLine());
 
-            var vssConnection = await CreateVssConnection();
+            var vssConnection = CreateVssConnection();
 
             var workItemTrackingHttpClient = vssConnection.GetClient<WorkItemTrackingHttpClient>();
             var workItem = await workItemTrackingHttpClient.GetWorkItemAsync(workItemId);
@@ -36,37 +36,27 @@ namespace ServicePrincipalsSamples
             Console.WriteLine($"Work Item Title: {workItem.Fields["System.Title"]}");
         }
 
-        private static async Task<VssConnection> CreateVssConnection()
-        {
-            var accessToken = await GetManagedIdentityAccessToken();
-            var token = new VssAadToken("Bearer", accessToken);
-            var credentials = new VssAadCredential(token);
-
-            var settings = VssClientHttpRequestSettings.Default.Clone();
-            settings.UserAgent = AppUserAgent;
-
-            var organizationUrl = new Uri(new Uri(AdoBaseUrl), AdoOrgName);
-            return new VssConnection(organizationUrl, credentials, settings);
-        }
-
-        private static async Task<string> GetManagedIdentityAccessToken()
+        private static VssConnection CreateVssConnection()
         {
             // DefaultAzureCredential will use VisualStudioCredentials or other appropriate credentials for local development
             // but will use ManagedIdentityCredential when deployed to an Azure Host with Managed Identity enabled.
             // https://learn.microsoft.com/en-us/dotnet/api/overview/azure/identity-readme?view=azure-dotnet#defaultazurecredential
-            var credential =
+            var credentials = new VssAzureIdentityCredential(
                 new DefaultAzureCredential(
                     new DefaultAzureCredentialOptions
                     {
                         TenantId = AadTenantId,
                         ManagedIdentityClientId = AadUserAssignedManagedIdentityClientId,
                         ExcludeEnvironmentCredential = true // Excluding because EnvironmentCredential was not using correct identity when running in Visual Studio
-                    });
+                    }
+                )
+            );
 
-            var tokenRequestContext = new TokenRequestContext(VssAadSettings.DefaultScopes);
-            var token = await credential.GetTokenAsync(tokenRequestContext, CancellationToken.None);
+            var settings = VssClientHttpRequestSettings.Default.Clone();
+            settings.UserAgent = AppUserAgent;
 
-            return token.Token;
+            var organizationUrl = new Uri(new Uri(AdoBaseUrl), AdoOrgName);
+            return new VssConnection(organizationUrl, credentials, settings);
         }
     }
 }

--- a/ServicePrincipalsSamples/ClientLibsNET/3-AzureFunction-ManagedIdentity/3-AzureFunction-ManagedIdentity.csproj
+++ b/ServicePrincipalsSamples/ClientLibsNET/3-AzureFunction-ManagedIdentity/3-AzureFunction-ManagedIdentity.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.1" />
-    <PackageReference Include="Azure.Identity" Version="1.8.2" />
-    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="19.219.0-preview" />
-    <PackageReference Include="Microsoft.VisualStudio.Services.InteractiveClient" Version="19.219.0-preview" />
+    <PackageReference Include="Azure.Identity" Version="1.11.3" />
+    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="19.239.0-preview" />
+    <PackageReference Include="Microsoft.VisualStudio.Services.InteractiveClient" Version="19.239.0-preview" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/ServicePrincipalsSamples/ClientLibsNET/3-AzureFunction-ManagedIdentity/TestMIHttpTrigger.cs
+++ b/ServicePrincipalsSamples/ClientLibsNET/3-AzureFunction-ManagedIdentity/TestMIHttpTrigger.cs
@@ -57,7 +57,7 @@ namespace Company.Function
                 return new BadRequestObjectResult($"Invalid Work item ID: {req.Query["workItemId"]}.");
             }
 
-            var vssConnection = await CreateVssConnection();
+            var vssConnection = CreateVssConnection();
 
             var workItemTrackingHttpClient = vssConnection.GetClient<WorkItemTrackingHttpClient>();
             
@@ -75,11 +75,9 @@ namespace Company.Function
             }
         }
 
-        private static async Task<VssConnection> CreateVssConnection()
+        private static VssConnection CreateVssConnection()
         {
-            var accessToken = await GetManagedIdentityAccessToken();
-            var token = new VssAadToken("Bearer", accessToken);
-            var credentials = new VssAadCredential(token);
+            var credentials = new VssAzureIdentityCredential(credential);
 
             var settings = VssClientHttpRequestSettings.Default.Clone();
             settings.UserAgent = AppUserAgent;
@@ -87,14 +85,5 @@ namespace Company.Function
             var organizationUrl = new Uri(new Uri(AdoBaseUrl), AdoOrgName);
             return new VssConnection(organizationUrl, credentials, settings);
         }
-
-        private static async Task<string> GetManagedIdentityAccessToken()
-        {
-            var tokenRequestContext = new TokenRequestContext(VssAadSettings.DefaultScopes);
-            var token = await credential.GetTokenAsync(tokenRequestContext, CancellationToken.None);
-
-            return token.Token;
-        }
-
     }
 }


### PR DESCRIPTION
This has a number of advantages over the approaches shown here. We get things like automatic token refreshes for free, and the logic is overall much clearer. I threw in some drive-by package updates to Azure.Identity dependencies, because `dotnet build` was complaining that the versions referenced had security issues.